### PR TITLE
refactor(fungus): route judge through openfang

### DIFF
--- a/src/embeddinggemma/tools/judge_runner.py
+++ b/src/embeddinggemma/tools/judge_runner.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
-from typing import Any, List
+from typing import List
 
+from vibemind_shared import get_client_sync, get_model
 from embeddinggemma.llm.prompts import build_judge_prompt
-from embeddinggemma.llm import generate_text  # type: ignore
 
 
 def _parse_json_loose(raw: str) -> dict:
@@ -30,27 +29,10 @@ def _parse_json_loose(raw: str) -> dict:
 
 
 def main() -> None:
-    # Load .env so API keys/base URLs are available
-    try:
-        from dotenv import load_dotenv  # type: ignore
-        load_dotenv()
-    except Exception:
-        pass
     ap = argparse.ArgumentParser(description="Isolated judge runner for steering mode")
     ap.add_argument('--query', required=True, help='User query')
     ap.add_argument('--results', required=True, help='Path to JSON file with items [{id, score, content}]')
     ap.add_argument('--mode', default='steering', help='Judge mode (default: steering)')
-    ap.add_argument('--provider', default=os.environ.get('LLM_PROVIDER', 'ollama'))
-    # Optional overrides
-    ap.add_argument('--system', default=os.environ.get('OLLAMA_SYSTEM'))
-    ap.add_argument('--ollama-model', dest='ollama_model', default=os.environ.get('OLLAMA_MODEL', 'qwen2.5-coder:7b'))
-    ap.add_argument('--ollama-host', dest='ollama_host', default=os.environ.get('OLLAMA_HOST', 'http://127.0.0.1:11434'))
-    ap.add_argument('--openai-model', dest='openai_model', default=os.environ.get('OPENAI_MODEL', 'gpt-4o-mini'))
-    ap.add_argument('--openai-temperature', dest='openai_temperature', type=float, default=float(os.environ.get('OPENAI_TEMPERATURE', '0.0')))
-    ap.add_argument('--google-model', dest='google_model', default=os.environ.get('GOOGLE_MODEL', 'gemini-1.5-pro'))
-    ap.add_argument('--google-temperature', dest='google_temperature', type=float, default=float(os.environ.get('GOOGLE_TEMPERATURE', '0.0')))
-    ap.add_argument('--grok-model', dest='grok_model', default=os.environ.get('GROK_MODEL', 'grok-2-latest'))
-    ap.add_argument('--grok-temperature', dest='grok_temperature', type=float, default=float(os.environ.get('GROK_TEMPERATURE', '0.0')))
     ap.add_argument('--out', default='-')
     args = ap.parse_args()
 
@@ -59,31 +41,11 @@ def main() -> None:
 
     prompt = build_judge_prompt(args.mode, args.query, items)
 
-    text = generate_text(
-        provider=args.provider,
-        prompt=prompt,
-        system=args.system,
-        # ollama
-        ollama_model=args.ollama_model,
-        ollama_host=args.ollama_host,
-        ollama_options=None,
-        # openai
-        openai_model=args.openai_model,
-        openai_api_key=os.environ.get('OPENAI_API_KEY', ''),
-        openai_base_url=os.environ.get('OPENAI_BASE_URL', 'https://api.openai.com'),
-        openai_temperature=float(args.openai_temperature),
-        # google
-        google_model=args.google_model,
-        google_api_key=os.environ.get('GOOGLE_API_KEY', ''),
-        google_base_url=os.environ.get('GOOGLE_BASE_URL', 'https://generativelanguage.googleapis.com'),
-        google_temperature=float(args.google_temperature),
-        # grok
-        grok_model=args.grok_model,
-        grok_api_key=os.environ.get('GROK_API_KEY', ''),
-        grok_base_url=os.environ.get('GROK_BASE_URL', 'https://api.x.ai'),
-        grok_temperature=float(args.grok_temperature),
-        save_prompt_path=None,
+    completion = get_client_sync("fungus_judge").chat.completions.create(
+        model=get_model("fungus_judge"),
+        messages=[{"role": "user", "content": prompt}],
     )
+    text = completion.choices[0].message.content
 
     obj = _parse_json_loose(text or "")
     out = json.dumps(obj, ensure_ascii=False, indent=2)

--- a/tests/tools/test_judge_runner.py
+++ b/tests/tools/test_judge_runner.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _load_judge_runner(monkeypatch, *, client, model: str = "openfang-judge-model"):
+    src_dir = Path(__file__).resolve().parents[2] / "src"
+    monkeypatch.syspath_prepend(str(src_dir))
+
+    shared = types.ModuleType("vibemind_shared")
+    def get_client_sync(role: str):
+        assert role == "fungus_judge"
+        return client
+
+    def get_model(role: str):
+        assert role == "fungus_judge"
+        return model
+
+    shared.get_client_sync = get_client_sync
+    shared.get_model = get_model
+    monkeypatch.setitem(sys.modules, "vibemind_shared", shared)
+    sys.modules.pop("embeddinggemma.tools.judge_runner", None)
+    return importlib.import_module("embeddinggemma.tools.judge_runner")
+
+
+def test_main_uses_openfang_judge_role_and_preserves_json_output(monkeypatch, tmp_path, capsys):
+    calls: dict[str, object] = {}
+
+    class Completions:
+        def create(self, **kwargs):
+            calls.update(kwargs)
+            return types.SimpleNamespace(
+                choices=[types.SimpleNamespace(message=types.SimpleNamespace(content='{"items": []}'))]
+            )
+
+    client = types.SimpleNamespace(chat=types.SimpleNamespace(completions=Completions()))
+    runner = _load_judge_runner(monkeypatch, client=client)
+    results = tmp_path / "results.json"
+    results.write_text(json.dumps([{"id": 7, "score": 0.8, "content": "relevant chunk"}]), encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["judge_runner", "--query", "find the handler", "--results", str(results)])
+
+    runner.main()
+
+    assert calls["model"] == "openfang-judge-model"
+    messages = calls["messages"]
+    assert isinstance(messages, list)
+    assert messages[0]["role"] == "user"
+    assert "find the handler" in messages[0]["content"]
+    assert json.loads(capsys.readouterr().out) == {"items": []}
+
+
+def test_main_propagates_openfang_client_failure_without_fallback(monkeypatch, tmp_path):
+    class UnavailableShared(types.ModuleType):
+        def get_client_sync(self, role):
+            raise RuntimeError("OpenFang unavailable")
+
+        def get_model(self, role):
+            raise AssertionError("model must not be resolved after client failure")
+
+    src_dir = Path(__file__).resolve().parents[2] / "src"
+    monkeypatch.syspath_prepend(str(src_dir))
+    monkeypatch.setitem(sys.modules, "vibemind_shared", UnavailableShared("vibemind_shared"))
+    sys.modules.pop("embeddinggemma.tools.judge_runner", None)
+    runner = importlib.import_module("embeddinggemma.tools.judge_runner")
+    results = tmp_path / "results.json"
+    results.write_text("[]", encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["judge_runner", "--query", "q", "--results", str(results)])
+
+    with pytest.raises(RuntimeError, match="OpenFang unavailable"):
+        runner.main()
+
+
+def test_cli_rejects_provider_override(monkeypatch, tmp_path):
+    client = types.SimpleNamespace(chat=types.SimpleNamespace(completions=object()))
+    runner = _load_judge_runner(monkeypatch, client=client)
+    results = tmp_path / "results.json"
+    results.write_text("[]", encoding="utf-8")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["judge_runner", "--query", "q", "--results", str(results), "--provider", "ollama"],
+    )
+
+    with pytest.raises(SystemExit, match="2"):
+        runner.main()


### PR DESCRIPTION
## Scope

Routes the Fungus CLI judge through the shared synchronous OpenFang client only:

- uses `get_client_sync("fungus_judge")` and `get_model("fungus_judge")`
- removes provider selection, local Ollama, direct API-key/base-URL handling and dotenv loading
- retains the JSON stdout/file output contract
- propagates Shared/OpenFang failures without a fallback

## Verification

- `py -3.10 -m pytest tests/tools/test_judge_runner.py -q` -> 3 passed
- `py -3.10 -m pytest tests -q --maxfail=1 --disable-warnings --import-mode=importlib` -> 25 passed
- `py -3.10 -m py_compile src/embeddinggemma/tools/judge_runner.py tests/tools/test_judge_runner.py`
- focused `audit_llm_usage.py` -> 0 direct targets, 1 migrated file
- authority-pattern and `git diff --check` scans clean

## Runtime boundary / non-claims

`fungus_judge` is intentionally not duplicated in this child repository. Its canonical definition is supplied by the parent `vibemind-os/llm_config.yml.example` through `VIBEMIND_CONFIG_DIR`. This PR does not prove a live OpenFang gateway, credentials, or an end-to-end judge execution.