### PR TITLE
fix(fungus): route residual LLM calls through OpenFang

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -593,31 +593,19 @@ async def fungus_search_multi(queries: str, top_k: int = 5) -> str:
 # Stage-6 (Ant-Colony) + Stage-7 (Query-Expansion) + Stage-5 (LLM-Judge)
 # ═════════════════════════════════════════════════════════════════════════
 
-# --- shared LLM helper (used by stages 5 + 7) ---------------------------
-_OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://127.0.0.1:11434")
-_LLM_MODEL = os.environ.get("FUNGUS_LLM_MODEL", "qwen2.5-coder:7b")
+# --- fixed OpenFang LLM paths (used by stages 5, 7, and 13) ------------
+def _generate_summary(prompt: str) -> str:
+    """Generate through the fixed OpenFang fungus_summary role."""
+    from embeddinggemma.rag.generation import generate_text
+
+    return generate_text(prompt=prompt)
 
 
-def _ollama_generate(prompt: str, model: str | None = None, timeout: int = 60) -> str:
-    """Call Ollama /api/generate synchronously. Returns text or empty string on error."""
-    import urllib.request, json as _json
-    body = _json.dumps({
-        "model": model or _LLM_MODEL,
-        "prompt": prompt,
-        "stream": False,
-        "options": {"temperature": 0.0, "num_ctx": 4096},
-    }).encode("utf-8")
-    try:
-        req = urllib.request.Request(
-            f"{_OLLAMA_HOST}/api/generate",
-            data=body, headers={"Content-Type": "application/json"},
-        )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            data = _json.loads(resp.read().decode("utf-8"))
-            return data.get("response", "")
-    except Exception as e:
-        logger.warning("ollama call failed: %s", e)
-        return ""
+def _generate_judge(prompt: str) -> str:
+    """Generate through the fixed OpenFang fungus_judge role."""
+    from embeddinggemma.rag.generation import generate_judge_text
+
+    return generate_judge_text(prompt=prompt)
 
 
 def _strip_json(text: str) -> str:
@@ -727,7 +715,7 @@ async def fungus_search_expanded(query: str, top_k: int = 10,
                                  n_subqueries: int = 4) -> str:
     """Expand the user query into N sub-queries via LLM, then merge results.
 
-    The LLM (default: qwen2.5-coder:7b via Ollama) rewrites the query into
+    The OpenFang summary role rewrites the query into
     several angles ("synonyms", "related concepts", "specific identifiers",
     "alternative wordings") so that the embedder + BM25 catch matches that
     a single phrasing would miss. Especially helpful when the user query
@@ -754,7 +742,7 @@ async def fungus_search_expanded(query: str, top_k: int = 10,
         f"phrasings. Return ONLY a JSON array of strings, nothing else.\n\n"
         f"Original query: {query}\n\nJSON array:"
     )
-    raw = await asyncio.to_thread(_ollama_generate, expand_prompt)
+    raw = await asyncio.to_thread(_generate_summary, expand_prompt)
     sub_queries: list[str] = []
     js = _strip_json(raw)
     try:
@@ -861,7 +849,7 @@ async def fungus_search_judged(query: str, top_k: int = 10,
     )
 
     t0 = time.time()
-    raw = await asyncio.to_thread(_ollama_generate, judge_prompt, None, 180)
+    raw = await asyncio.to_thread(_generate_judge, judge_prompt)
     js = _strip_json(raw)
     judgements: dict[int, dict] = {}
     try:
@@ -1056,7 +1044,7 @@ async def fungus_search_validated(query: str, top_k: int = 10,
             f"Generate 0-3 follow-up queries.\n\nJSON:"
         )
 
-        raw = await asyncio.to_thread(_ollama_generate, validator_prompt, None, 90)
+        raw = await asyncio.to_thread(_generate_judge, validator_prompt)
         js = _strip_json(raw)
         followups: list[str] = []
         gap_reason = ""
@@ -1210,7 +1198,7 @@ async def fungus_search_synthesized(query: str, top_k: int = 10,
                 f'Return ONLY JSON: {{"gaps_identified": <bool>, '
                 f'"why": "<short>", "followup_queries": [...]}}\n\nJSON:'
             )
-            raw = _ollama_generate(prompt, None, 90)
+            raw = _generate_judge(prompt)
             js = _strip_json(raw)
             followups = []
             try:
@@ -1373,7 +1361,7 @@ async def fungus_search_synthesized(query: str, top_k: int = 10,
     )
 
     t1 = time.time()
-    raw = await asyncio.to_thread(_ollama_generate, synth_prompt, None, 240)
+    raw = await asyncio.to_thread(_generate_summary, synth_prompt)
     synth_time = time.time() - t1
 
     js = _strip_json(raw)

--- a/src/embeddinggemma/ui/queries.py
+++ b/src/embeddinggemma/ui/queries.py
@@ -1,6 +1,7 @@
-import os
 import re
 from typing import List
+
+from embeddinggemma.rag.generation import generate_text
 
 
 def _normalize_query_text(text: str) -> str:
@@ -74,23 +75,6 @@ def dedup_multi_queries(queries: List[str], similarity_threshold: float = 0.8) -
     return kept
 
 
-def _ollama_generate(prompt: str, model: str = None, timeout: int = 180) -> str:
-    try:
-        import requests
-        host = os.environ.get('OLLAMA_HOST', 'http://127.0.0.1:11434').rstrip('/')
-        model_name = model or os.environ.get('OLLAMA_MODEL', 'qwen2.5-coder:7b')
-        r = requests.post(
-            f"{host}/api/generate",
-            json={"model": model_name, "prompt": prompt, "stream": False, "options": {"temperature": 0.1}},
-            timeout=timeout,
-        )
-        if r.ok:
-            return r.json().get('response', '')
-        return f"[LLM error] status={r.status_code}"
-    except Exception as e:
-        return f"[LLM error] {e}"
-
-
 def generate_multi_queries_from_llm(base_query: str, num_queries: int = 5, context_files: List[str] = None, keyword_hints: List[str] = None) -> List[str]:
     print(f"Generating {num_queries} queries for {base_query}")
     print(f"Context files: {context_files}")
@@ -119,7 +103,7 @@ def generate_multi_queries_from_llm(base_query: str, num_queries: int = 5, conte
     ]
     sys_prompt = "\n".join(lines_prompt).replace("{n}", str(n))
     user = f"Base query: {base_query}\nWrite {n} concrete repository search questions (one per line), grounded in the hinted files."
-    text = _ollama_generate(f"System:\n{sys_prompt}\n\nUser:\n{user}")
+    text = generate_text(prompt=user, system=sys_prompt)
     lines = [re.sub(r"^[\-\d\.\)\s]+", "", ln).strip() for ln in (text or "").splitlines()]
     lines = [ln for ln in lines if ln]
     return lines[:n]

--- a/tests/tools/test_mcp_server_openfang.py
+++ b/tests/tools/test_mcp_server_openfang.py
@@ -1,0 +1,46 @@
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_mcp_server(monkeypatch):
+    calls = []
+    generation = ModuleType("embeddinggemma.rag.generation")
+
+    def generate_text(**kwargs):
+        calls.append(("summary", kwargs))
+        return "summary"
+
+    def generate_judge_text(**kwargs):
+        calls.append(("judge", kwargs))
+        return "judgement"
+
+    generation.generate_text = generate_text
+    generation.generate_judge_text = generate_judge_text
+    monkeypatch.setitem(sys.modules, "embeddinggemma.rag.generation", generation)
+    sys.modules.pop("mcp_server", None)
+    return importlib.import_module("mcp_server"), calls
+
+
+def test_mcp_llm_helpers_use_fixed_openfang_paths(monkeypatch):
+    server, calls = _load_mcp_server(monkeypatch)
+
+    assert server._generate_summary("Expand this") == "summary"
+    assert server._generate_judge("Judge this") == "judgement"
+    assert calls == [
+        ("summary", {"prompt": "Expand this"}),
+        ("judge", {"prompt": "Judge this"}),
+    ]
+
+
+def test_mcp_active_llm_call_sites_do_not_use_direct_provider_helper():
+    source = (ROOT / "mcp_server.py").read_text(encoding="utf-8")
+
+    assert "def _ollama_generate" not in source
+    assert source.count("asyncio.to_thread(_generate_summary,") == 2
+    assert source.count("asyncio.to_thread(_generate_judge,") == 2
+    assert "raw = _generate_judge(prompt)" in source

--- a/tests/tools/test_mcp_server_openfang.py
+++ b/tests/tools/test_mcp_server_openfang.py
@@ -7,6 +7,28 @@ from types import ModuleType
 ROOT = Path(__file__).resolve().parents[2]
 
 
+def _install_fastmcp_stub(monkeypatch):
+    mcp_package = ModuleType("mcp")
+    mcp_package.__path__ = []
+    server_package = ModuleType("mcp.server")
+    server_package.__path__ = []
+    fastmcp_module = ModuleType("mcp.server.fastmcp")
+
+    class FastMCP:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def tool(self):
+            return lambda function: function
+
+    fastmcp_module.FastMCP = FastMCP
+    mcp_package.server = server_package
+    server_package.fastmcp = fastmcp_module
+    monkeypatch.setitem(sys.modules, "mcp", mcp_package)
+    monkeypatch.setitem(sys.modules, "mcp.server", server_package)
+    monkeypatch.setitem(sys.modules, "mcp.server.fastmcp", fastmcp_module)
+
+
 def _load_mcp_server(monkeypatch):
     calls = []
     generation = ModuleType("embeddinggemma.rag.generation")
@@ -22,6 +44,7 @@ def _load_mcp_server(monkeypatch):
     generation.generate_text = generate_text
     generation.generate_judge_text = generate_judge_text
     monkeypatch.setitem(sys.modules, "embeddinggemma.rag.generation", generation)
+    _install_fastmcp_stub(monkeypatch)
     sys.modules.pop("mcp_server", None)
     return importlib.import_module("mcp_server"), calls
 

--- a/tests/ui/test_queries_openfang.py
+++ b/tests/ui/test_queries_openfang.py
@@ -1,0 +1,35 @@
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+SRC = Path(__file__).resolve().parents[2] / "src"
+
+
+def _load_queries(monkeypatch):
+    generation = ModuleType("embeddinggemma.rag.generation")
+    generation.generate_text = lambda **_kwargs: ""
+    monkeypatch.setitem(sys.modules, "embeddinggemma.rag.generation", generation)
+    sys.path.insert(0, str(SRC))
+    sys.modules.pop("embeddinggemma.ui.queries", None)
+    return importlib.import_module("embeddinggemma.ui.queries")
+
+
+def test_multi_query_generation_uses_fixed_openfang_summary_path(monkeypatch):
+    queries = _load_queries(monkeypatch)
+    calls = []
+
+    def generate_text(**kwargs):
+        calls.append(kwargs)
+        return "first repository query\nsecond repository query"
+
+    monkeypatch.setattr(queries, "generate_text", generate_text, raising=False)
+
+    result = queries.generate_multi_queries_from_llm("find search routing", num_queries=2)
+
+    assert result == ["first repository query", "second repository query"]
+    assert calls and calls[0]["prompt"].startswith("Base query: find search routing")
+    assert "System:" not in calls[0]["prompt"]
+    assert calls[0]["system"].startswith("You reformulate a single repository question")
+    assert not hasattr(queries, "_ollama_generate")


### PR DESCRIPTION
## Summary\n- replace active MCP-server direct Ollama generation with fixed OpenFang summary and judge paths\n- route UI multi-query generation through the fixed OpenFang summary path\n- add regression coverage for helpers and all active MCP call sites\n\n## Verification\n- py -3.10 -m pytest tests -q (48 passed)\n- py -3.10 -m py_compile mcp_server.py src/embeddinggemma/ui/queries.py src/embeddinggemma/rag/generation.py tests/tools/test_mcp_server_openfang.py tests/ui/test_queries_openfang.py\n- git diff --check\n\n## Scope / non-claims\n- no merge, deployment, live OpenFang call, cache mutation, or database mutation was performed\n- legacy unused direct-provider configuration remains unchanged pending separate removal evidence