### PR TITLE
fix(fungus): serialize updater and lazy-load MCP

### DIFF
--- a/incremental_updater.py
+++ b/incremental_updater.py
@@ -37,12 +37,14 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import BinaryIO
 
 # Repo paths (hardcoded by design — see plan, matches build_vibemind_cpu.py:18)
 REPO_ROOT = Path("c:/Users/User/Desktop/Vibemind_V1")
 CODEBASE = REPO_ROOT / "vibemind-os"
 FUNGUS_ROOT = CODEBASE / "la-fungus-search"
 LOG_DIR = REPO_ROOT / "backups"
+DEFAULT_LOCK_FILE = LOG_DIR / "fungus_incremental_updater.lock"
 
 WINDOWS = [200]
 FILE_PREFIX_RE = re.compile(r"^# file: (.+?) \| lines:")
@@ -54,6 +56,59 @@ EXCLUDE_DIRS = {
     "downloads", ".pitchdeck_chroma", ".playwright-mcp",
     "uv.lock", ".kilocode", ".vscode",
 }
+
+
+# ── machine-wide singleton ──────────────────────────────────────────────────
+
+def acquire_singleton_lock(lock_path: Path | None = None) -> BinaryIO | None:
+    """Acquire the one machine-wide incremental-updater slot.
+
+    The file remains on disk for diagnostics, while the OS lock is tied to the
+    open handle and is therefore released automatically if the process dies.
+    """
+    configured = os.environ.get("FUNGUS_UPDATER_LOCK_FILE", "").strip()
+    path = Path(lock_path or configured or DEFAULT_LOCK_FILE)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = path.open("a+b")
+    try:
+        handle.seek(0, os.SEEK_END)
+        if handle.tell() == 0:
+            handle.write(b"\0")
+            handle.flush()
+        handle.seek(0)
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        handle.close()
+        return None
+
+    handle.seek(0)
+    handle.truncate()
+    handle.write(f"{os.getpid()}\n".encode("ascii"))
+    handle.flush()
+    return handle
+
+
+def release_singleton_lock(handle: BinaryIO) -> None:
+    """Release a lock returned by :func:`acquire_singleton_lock`."""
+    try:
+        handle.seek(0)
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    finally:
+        handle.close()
 
 
 # ── logging ──────────────────────────────────────────────────────────────────
@@ -258,22 +313,7 @@ def background_self() -> None:
 
 # ── main ─────────────────────────────────────────────────────────────────────
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
-    parser.add_argument("--background", action="store_true",
-                        help="self-detach and exit immediately (for git-hook)")
-    parser.add_argument("--since", default="HEAD~1",
-                        help="git ref to diff against (default: HEAD~1)")
-    parser.add_argument("--repo-cwd", default=None,
-                        help="repo the commit happened in (set by the git hook)")
-    parser.add_argument("--dry-run", action="store_true",
-                        help="print plan without modifying index")
-    args = parser.parse_args()
-
-    if args.background:
-        background_self()
-        return 0
-
+def _run_with_args(args: argparse.Namespace) -> int:
     log = setup_logging()
     t0 = time.time()
     repo_cwd = Path(args.repo_cwd).resolve() if args.repo_cwd else None
@@ -446,6 +486,32 @@ def main() -> int:
         f"({removed_count} removed, {len(new_chunks)} added) ==="
     )
     return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--background", action="store_true",
+                        help="self-detach and exit immediately (for git-hook)")
+    parser.add_argument("--since", default="HEAD~1",
+                        help="git ref to diff against (default: HEAD~1)")
+    parser.add_argument("--repo-cwd", default=None,
+                        help="repo the commit happened in (set by the git hook)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="print plan without modifying index")
+    args = parser.parse_args()
+
+    if args.background:
+        background_self()
+        return 0
+
+    lock_handle = acquire_singleton_lock()
+    if lock_handle is None:
+        print("[fungus-inc] updater already running; exiting", file=sys.stderr)
+        return 0
+    try:
+        return _run_with_args(args)
+    finally:
+        release_singleton_lock(lock_handle)
 
 
 if __name__ == "__main__":

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -59,9 +59,9 @@ EXCLUDE_DIRS = [
 ]
 
 # ---------------------------------------------------------------------------
-# Lazy / background loading — heavy work runs in a daemon thread so
-# mcp.run() (and the MCP handshake) can start immediately.  Tool calls
-# that need the retriever or multivec wait on _ready_event.
+# Lazy / background loading — MCP startup and handshake stay lightweight.
+# The first tool call that actually needs the retriever starts one daemon
+# loader; later queries share the same ready event.
 # ---------------------------------------------------------------------------
 import threading as _threading
 
@@ -154,17 +154,35 @@ def _background_load():
     logger.info("Background load complete.")
 
 
-_bg_thread = _threading.Thread(target=_background_load, daemon=True, name="fungus-bg-load")
-_bg_thread.start()
+_bg_thread: _threading.Thread | None = None
+_bg_thread_lock = _threading.Lock()
+
+
+def _start_background_load() -> None:
+    """Start the heavy retriever load once, on first real query."""
+    global _bg_thread
+    if _ready_event.is_set():
+        return
+    with _bg_thread_lock:
+        if _ready_event.is_set():
+            return
+        if _bg_thread is None or not _bg_thread.is_alive():
+            _bg_thread = _threading.Thread(
+                target=_background_load,
+                daemon=True,
+                name="fungus-bg-load",
+            )
+            _bg_thread.start()
 
 
 def _ensure_ready(timeout: float = 300.0) -> bool:
-    """Block until background load finishes (or timeout). Returns True if ready.
+    """Start the lazy loader and wait until it finishes (or timeout).
 
-    Default 120s (was 30s): the cold start loads model weights + index in ~50s.
+    The cold start loads model weights + index in ~50s.
     A 30s wait expired mid-load, so the FIRST search after a reconnect returned a
     false "Index empty". Search tools genuinely need the retriever, so they wait
     here; index_stats does NOT (it reports load progress non-blockingly)."""
+    _start_background_load()
     return _ready_event.wait(timeout=timeout)
 
 
@@ -1582,12 +1600,12 @@ async def fungus_index_stats() -> str:
     """
     meta = dict(_index_meta)
 
-    # NON-BLOCKING: the heavy model+index load (~50s on a cold stdio start) runs
-    # in the _background_load daemon thread. Do NOT block on _ensure_ready here —
-    # that made index_stats hang for up to 30s on the first call after a reconnect
-    # (and the client read it as a hang). Instead report load progress instantly
-    # so the caller sees "still loading" and can retry, rather than a stalled tool.
+    # NON-BLOCKING: do not turn a status request into the first heavy query.
+    # Report whether the lazy loader has not started or is currently running.
     if not _ready_event.is_set():
+        if _bg_thread is None:
+            return ("Index not loaded yet (lazy start). Run a search query to "
+                    "start the retriever. Meta: " + str(meta))
         return ("Index still loading (cold start ~50s: model weights + index). "
                 "Retry in a moment. Meta: " + str(meta))
     if not _retriever or not _retriever.documents:

--- a/tests/tools/test_incremental_updater_singleton.py
+++ b/tests/tools/test_incremental_updater_singleton.py
@@ -1,0 +1,33 @@
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+UPDATER_PATH = ROOT / "incremental_updater.py"
+
+
+def _load_updater():
+    spec = importlib.util.spec_from_file_location("fungus_incremental_updater", UPDATER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_machine_singleton_rejects_second_holder_and_recovers_after_release(tmp_path):
+    updater = _load_updater()
+    assert hasattr(updater, "acquire_singleton_lock"), (
+        "incremental_updater must expose the machine-wide singleton boundary"
+    )
+
+    lock_path = tmp_path / "fungus-incremental-updater.lock"
+    first = updater.acquire_singleton_lock(lock_path)
+    assert first is not None
+    try:
+        assert updater.acquire_singleton_lock(lock_path) is None
+    finally:
+        updater.release_singleton_lock(first)
+
+    recovered = updater.acquire_singleton_lock(lock_path)
+    assert recovered is not None
+    updater.release_singleton_lock(recovered)

--- a/tests/tools/test_mcp_server_openfang.py
+++ b/tests/tools/test_mcp_server_openfang.py
@@ -1,5 +1,7 @@
+import asyncio
 import importlib
 import sys
+import threading
 from pathlib import Path
 from types import ModuleType
 
@@ -67,3 +69,60 @@ def test_mcp_active_llm_call_sites_do_not_use_direct_provider_helper():
     assert source.count("asyncio.to_thread(_generate_summary,") == 2
     assert source.count("asyncio.to_thread(_generate_judge,") == 2
     assert "raw = _generate_judge(prompt)" in source
+
+
+def test_retriever_load_is_lazy_and_starts_once_on_first_query(monkeypatch):
+    class DeferredThread:
+        starts = 0
+        run_targets = False
+
+        def __init__(self, *, target, daemon=None, name=None):
+            self.target = target
+            self.daemon = daemon
+            self.name = name
+            self.started = False
+
+        def start(self):
+            type(self).starts += 1
+            self.started = True
+            if type(self).run_targets:
+                self.target()
+
+        def is_alive(self):
+            return self.started
+
+    monkeypatch.setattr(threading, "Thread", DeferredThread)
+    server, _calls = _load_mcp_server(monkeypatch)
+
+    assert DeferredThread.starts == 0, "MCP import must not start the heavy retriever"
+    assert server._bg_thread is None
+
+    monkeypatch.setattr(server, "_background_load", server._ready_event.set)
+    DeferredThread.run_targets = True
+
+    assert server._ensure_ready(timeout=0.1) is True
+    assert DeferredThread.starts == 1
+    assert server._ensure_ready(timeout=0.1) is True
+    assert DeferredThread.starts == 1
+
+
+def test_index_stats_reports_lazy_state_without_starting_loader(monkeypatch):
+    class NoStartThread:
+        starts = 0
+
+        def __init__(self, *, target, daemon=None, name=None):
+            self.target = target
+
+        def start(self):
+            type(self).starts += 1
+
+        def is_alive(self):
+            return False
+
+    monkeypatch.setattr(threading, "Thread", NoStartThread)
+    server, _calls = _load_mcp_server(monkeypatch)
+
+    result = asyncio.run(server.fungus_index_stats())
+
+    assert "not loaded yet" in result.lower()
+    assert NoStartThread.starts == 0


### PR DESCRIPTION
## Outcome
- enforce one machine-wide incremental updater via OS-backed lockfile
- exit duplicate updater processes immediately without model/index work
- defer the heavy MCP retriever/index loader until the first query that calls _ensure_ready
- report an honest not-loaded-yet state from index stats

## Root cause
Each Codex task starts its own Fungus MCP process, and the module previously started the heavy retriever during import. Concurrent task commits also detached independent incremental updaters through the shared post-commit hook. Together these processes exhausted committed memory and blocked new process creation.

## TDD evidence
- RED: singleton API absent; second holder was not rejected
- RED: MCP import started one loader thread before any query
- RED: index stats claimed loading although lazy load had not started
- GREEN: 50 passed, 1 skipped
- process proof: duplicate updater exited 0 in 0.047s with 'already running'
- runtime proof: MCP before first query used 75.3 MiB working set / 832.5 MiB committed memory

## Boundaries
No deploy, cache rebuild, index write, provider change, or unrelated refactor.