### PR TITLE
fix(fungus): start updater on first query

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -26,6 +26,7 @@ import logging
 import warnings
 import hashlib
 import json
+import subprocess
 
 # Ensure src/ is importable
 _HERE = os.path.dirname(os.path.abspath(__file__))
@@ -156,6 +157,66 @@ def _background_load():
 
 _bg_thread: _threading.Thread | None = None
 _bg_thread_lock = _threading.Lock()
+_updater_spawn_lock = _threading.Lock()
+_updater_spawn_attempted = False
+_updater_spawn_error: Exception | None = None
+_UPDATER_WRAPPER_TIMEOUT_S = 5.0
+_UPDATER_WRAPPER_TERMINATE_TIMEOUT_S = 1.0
+
+
+def _raise_updater_spawn_failure(cause: Exception) -> None:
+    global _updater_spawn_error
+    _updater_spawn_error = cause
+    logger.error("Incremental updater launch failed; refusing retriever query: %s", cause)
+    raise RuntimeError(
+        "incremental updater could not start; retriever query refused"
+    ) from cause
+
+
+def _start_incremental_updater_once() -> None:
+    """Start the updater once per MCP process before retriever-backed work.
+
+    The updater itself owns the machine-wide OS lock.  This local guard only
+    prevents concurrent MCP queries from creating redundant detached parents.
+    A launch failure is surfaced to the query instead of silently continuing.
+    """
+    global _updater_spawn_attempted, _updater_spawn_error
+
+    with _updater_spawn_lock:
+        if _updater_spawn_attempted:
+            if _updater_spawn_error is not None:
+                raise RuntimeError(
+                    "incremental updater could not start; retriever query refused"
+                ) from _updater_spawn_error
+            return
+
+        _updater_spawn_attempted = True
+        try:
+            wrapper = subprocess.Popen(
+                [sys.executable, os.path.join(_HERE, "incremental_updater.py"), "--background"],
+                cwd=_HERE,
+                shell=False,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except OSError as exc:
+            _raise_updater_spawn_failure(exc)
+
+        try:
+            return_code = wrapper.wait(timeout=_UPDATER_WRAPPER_TIMEOUT_S)
+        except subprocess.TimeoutExpired as exc:
+            try:
+                wrapper.terminate()
+                wrapper.wait(timeout=_UPDATER_WRAPPER_TERMINATE_TIMEOUT_S)
+            except (OSError, subprocess.TimeoutExpired) as cleanup_error:
+                logger.warning("Timed-out updater wrapper did not stop cleanly: %s", cleanup_error)
+            _raise_updater_spawn_failure(exc)
+
+        if return_code != 0:
+            _raise_updater_spawn_failure(
+                RuntimeError(f"incremental updater wrapper exited with code {return_code}")
+            )
 
 
 def _start_background_load() -> None:
@@ -183,6 +244,7 @@ def _ensure_ready(timeout: float = 300.0) -> bool:
     A 30s wait expired mid-load, so the FIRST search after a reconnect returned a
     false "Index empty". Search tools genuinely need the retriever, so they wait
     here; index_stats does NOT (it reports load progress non-blockingly)."""
+    _start_incremental_updater_once()
     _start_background_load()
     return _ready_event.wait(timeout=timeout)
 

--- a/tests/tools/test_incremental_updater_singleton.py
+++ b/tests/tools/test_incremental_updater_singleton.py
@@ -1,4 +1,6 @@
 import importlib.util
+import subprocess
+import sys
 from pathlib import Path
 
 
@@ -28,6 +30,45 @@ def test_machine_singleton_rejects_second_holder_and_recovers_after_release(tmp_
     finally:
         updater.release_singleton_lock(first)
 
+    recovered = updater.acquire_singleton_lock(lock_path)
+    assert recovered is not None
+    updater.release_singleton_lock(recovered)
+
+
+def test_machine_singleton_rejects_separate_process_and_recovers_after_exit(tmp_path):
+    """The OS-owned lock, not Python module state, fences another process."""
+    lock_path = tmp_path / "fungus-incremental-updater.lock"
+    holder = """
+import importlib.util
+import sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location("fungus_lock_holder", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+handle = module.acquire_singleton_lock(Path(sys.argv[2]))
+if handle is None:
+    raise SystemExit(2)
+print("locked", flush=True)
+if sys.stdin.readline().strip() != "release":
+    raise SystemExit(3)
+module.release_singleton_lock(handle)
+"""
+    process = subprocess.Popen(
+        [sys.executable, "-u", "-c", holder, str(UPDATER_PATH), str(lock_path)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert process.stdout is not None
+    assert process.stdout.readline().strip() == "locked"
+
+    updater = _load_updater()
+    assert updater.acquire_singleton_lock(lock_path) is None
+
+    stdout, stderr = process.communicate("release\n", timeout=5)
+    assert process.returncode == 0, stdout + stderr
     recovered = updater.acquire_singleton_lock(lock_path)
     assert recovered is not None
     updater.release_singleton_lock(recovered)

--- a/tests/tools/test_mcp_server_openfang.py
+++ b/tests/tools/test_mcp_server_openfang.py
@@ -1,9 +1,13 @@
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 import importlib
+import subprocess
 import sys
 import threading
 from pathlib import Path
 from types import ModuleType
+
+import pytest
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -126,3 +130,115 @@ def test_index_stats_reports_lazy_state_without_starting_loader(monkeypatch):
 
     assert "not loaded yet" in result.lower()
     assert NoStartThread.starts == 0
+
+
+def test_first_retriever_query_spawns_incremental_updater_once(monkeypatch):
+    """A process starts the updater only for the first retriever-requiring call."""
+    spawned = []
+
+    class SuccessfulWrapper:
+        def __init__(self):
+            self.wait_timeouts = []
+
+        def wait(self, *, timeout):
+            self.wait_timeouts.append(timeout)
+            return 0
+
+    wrapper = SuccessfulWrapper()
+
+    class FakeRetriever:
+        documents = [object()]
+
+        def search_direct(self, *_args, **_kwargs):
+            return {"results": []}
+
+    def fake_popen(args, **kwargs):
+        spawned.append((args, kwargs))
+        return wrapper
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    server, _calls = _load_mcp_server(monkeypatch)
+
+    assert hasattr(server, "_start_incremental_updater_once"), (
+        "retriever-requiring queries must own a process-local lazy updater spawn"
+    )
+    monkeypatch.setattr(sys, "executable", "isolated-python")
+    monkeypatch.setattr(server, "_background_load", server._ready_event.set)
+    server._retriever = FakeRetriever()
+    server._bm25 = None
+
+    assert "not loaded yet" in asyncio.run(server.fungus_index_stats()).lower()
+    assert spawned == []
+
+    start = threading.Barrier(3)
+
+    def enter_retriever_boundary():
+        start.wait(timeout=2)
+        return server._ensure_ready(timeout=0.1)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(enter_retriever_boundary) for _value in range(2)]
+        start.wait(timeout=2)
+        assert [future.result(timeout=2) for future in futures] == [True, True]
+
+    assert asyncio.run(server.fungus_search("lazy updater")) == "No results for: lazy updater"
+
+    assert len(spawned) == 1
+    args, kwargs = spawned[0]
+    assert args == [
+        "isolated-python",
+        str(ROOT / "incremental_updater.py"),
+        "--background",
+    ]
+    assert kwargs["cwd"] == str(ROOT)
+    assert kwargs["shell"] is False
+    assert wrapper.wait_timeouts == [server._UPDATER_WRAPPER_TIMEOUT_S]
+
+
+@pytest.mark.parametrize("failure_mode", ["nonzero", "timeout", "oserror"])
+def test_retriever_query_fails_closed_when_updater_wrapper_fails(
+    monkeypatch, failure_mode
+):
+    class FailedWrapper:
+        def __init__(self):
+            self.wait_timeouts = []
+            self.terminated = False
+
+        def wait(self, *, timeout):
+            self.wait_timeouts.append(timeout)
+            if failure_mode == "timeout" and len(self.wait_timeouts) == 1:
+                raise subprocess.TimeoutExpired("incremental-updater-wrapper", timeout)
+            return 9 if failure_mode == "nonzero" else 0
+
+        def terminate(self):
+            self.terminated = True
+
+    wrapper = FailedWrapper()
+    attempts = []
+
+    def fail_popen(*args, **kwargs):
+        attempts.append((args, kwargs))
+        if failure_mode == "oserror":
+            raise OSError("blocked")
+        return wrapper
+
+    monkeypatch.setattr(subprocess, "Popen", fail_popen)
+    server, _calls = _load_mcp_server(monkeypatch)
+
+    assert hasattr(server, "_start_incremental_updater_once"), (
+        "updater spawn failures must be surfaced before retriever loading"
+    )
+
+    with pytest.raises(RuntimeError, match="incremental updater"):
+        asyncio.run(server.fungus_search("must not pretend to search"))
+    with pytest.raises(RuntimeError, match="incremental updater"):
+        asyncio.run(server.fungus_search("still fail closed"))
+
+    assert len(attempts) == 1
+    assert server._bg_thread is None
+    if failure_mode == "timeout":
+        assert wrapper.terminated is True
+        assert wrapper.wait_timeouts == [
+            server._UPDATER_WRAPPER_TIMEOUT_S,
+            server._UPDATER_WRAPPER_TERMINATE_TIMEOUT_S,
+        ]

--- a/tests/tools/test_mcp_server_openfang.py
+++ b/tests/tools/test_mcp_server_openfang.py
@@ -35,7 +35,12 @@ def _install_fastmcp_stub(monkeypatch):
     monkeypatch.setitem(sys.modules, "mcp.server.fastmcp", fastmcp_module)
 
 
-def _load_mcp_server(monkeypatch):
+def _forbid_popen(*_args, **_kwargs):
+    raise AssertionError("subprocess.Popen requires an explicit hermetic test stub")
+
+
+def _load_mcp_server(monkeypatch, *, popen_stub=None):
+    monkeypatch.setattr(subprocess, "Popen", popen_stub or _forbid_popen)
     calls = []
     generation = ModuleType("embeddinggemma.rag.generation")
 
@@ -101,6 +106,12 @@ def test_retriever_load_is_lazy_and_starts_once_on_first_query(monkeypatch):
     assert DeferredThread.starts == 0, "MCP import must not start the heavy retriever"
     assert server._bg_thread is None
 
+    updater_boundaries = []
+    monkeypatch.setattr(
+        server,
+        "_start_incremental_updater_once",
+        lambda: updater_boundaries.append("start"),
+    )
     monkeypatch.setattr(server, "_background_load", server._ready_event.set)
     DeferredThread.run_targets = True
 
@@ -108,6 +119,7 @@ def test_retriever_load_is_lazy_and_starts_once_on_first_query(monkeypatch):
     assert DeferredThread.starts == 1
     assert server._ensure_ready(timeout=0.1) is True
     assert DeferredThread.starts == 1
+    assert updater_boundaries == ["start", "start"]
 
 
 def test_index_stats_reports_lazy_state_without_starting_loader(monkeypatch):
@@ -156,8 +168,7 @@ def test_first_retriever_query_spawns_incremental_updater_once(monkeypatch):
         spawned.append((args, kwargs))
         return wrapper
 
-    monkeypatch.setattr(subprocess, "Popen", fake_popen)
-    server, _calls = _load_mcp_server(monkeypatch)
+    server, _calls = _load_mcp_server(monkeypatch, popen_stub=fake_popen)
 
     assert hasattr(server, "_start_incremental_updater_once"), (
         "retriever-requiring queries must own a process-local lazy updater spawn"
@@ -222,8 +233,7 @@ def test_retriever_query_fails_closed_when_updater_wrapper_fails(
             raise OSError("blocked")
         return wrapper
 
-    monkeypatch.setattr(subprocess, "Popen", fail_popen)
-    server, _calls = _load_mcp_server(monkeypatch)
+    server, _calls = _load_mcp_server(monkeypatch, popen_stub=fail_popen)
 
     assert hasattr(server, "_start_incremental_updater_once"), (
         "updater spawn failures must be surfaced before retriever loading"


### PR DESCRIPTION
## Summary
- start the incremental updater once, lazily, at the first retriever-backed query
- retain the machine-wide OS lock as the cross-process authority
- fail closed when the wrapper cannot start, times out, or exits nonzero
- prove import/status remain spawn-free and a real second process cannot acquire the lock

## Verification
- RED: 2 failed, 6 passed
- review RED: 3 failed, 7 passed
- GREEN: 10 passed
- python -B -m py_compile mcp_server.py incremental_updater.py
- git diff --check

No live Fungus query, index build, model call, Docker call, or network runtime validation was performed.