### PR TITLE
fix(fungus): lazily hydrate BM25 cache

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -74,19 +74,35 @@ import numpy as _np  # for hybrid math
 from embeddinggemma.bm25_lite import BM25Lite as _BM25Lite
 
 _bm25: _BM25Lite | None = None
-try:
-    _bm25_path = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)),
-        ".fungus_cache", "bm25.npz",
-    )
-    if os.path.exists(_bm25_path):
-        _bm25 = _BM25Lite.load(_bm25_path)
-        logger.info("BM25 hybrid ready: vocab=%d docs=%d", len(_bm25.doc_freq), _bm25.N)
-    else:
-        logger.info("BM25 hybrid disabled (no bm25.npz at %s)", _bm25_path)
-except Exception as e:
-    logger.warning("BM25 load failed (continuing without hybrid): %s", e)
-    _bm25 = None
+_bm25_path = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    ".fungus_cache", "bm25.npz",
+)
+_bm25_load_lock = _threading.Lock()
+_bm25_load_attempted = False
+_bm25_load_error: Exception | None = None
+
+
+def _ensure_bm25_loaded() -> _BM25Lite | None:
+    """Hydrate the optional BM25 cache once, at a hybrid-search boundary."""
+    global _bm25, _bm25_load_attempted, _bm25_load_error
+
+    with _bm25_load_lock:
+        if _bm25_load_attempted:
+            return _bm25
+
+        _bm25_load_attempted = True
+        if not os.path.exists(_bm25_path):
+            logger.info("BM25 hybrid disabled (no bm25.npz at %s)", _bm25_path)
+            return None
+        try:
+            _bm25 = _BM25Lite.load(_bm25_path)
+            logger.info("BM25 hybrid ready: vocab=%d docs=%d", len(_bm25.doc_freq), _bm25.N)
+        except Exception as e:
+            _bm25_load_error = e
+            _bm25 = None
+            logger.warning("BM25 load failed (continuing without hybrid): %s", e)
+        return _bm25
 
 
 def _minmax(arr: _np.ndarray) -> _np.ndarray:
@@ -346,7 +362,9 @@ def _sync_search(query: str, top_k: int, alpha: float = 0.65) -> dict:
     _ensure_ready()
     if _retriever is None or not _retriever.documents:
         return {"results": []}
-    if _bm25 is None or alpha >= 0.999:
+    if alpha >= 0.999:
+        return _retriever.search_direct(query, top_k=top_k)
+    if _ensure_bm25_loaded() is None:
         return _retriever.search_direct(query, top_k=top_k)
 
     # Step 1: fetch a wide semantic pool (top 200 by cosine).
@@ -1566,7 +1584,7 @@ async def fungus_search_multivec(query: str, top_k: int = 10,
             })
 
     # Optional fusion with Stage-4 hybrid (gives us BM25 + file-type-boost)
-    if fuse_with_hybrid and _bm25 is not None:
+    if fuse_with_hybrid and _ensure_bm25_loaded() is not None:
         hybrid_res = _sync_search(query, top_k=80, alpha=0.65)
         hybrid_pool = hybrid_res.get("results", [])
         # Build {content_key → hybrid_score}

--- a/tests/tools/test_mcp_server_openfang.py
+++ b/tests/tools/test_mcp_server_openfang.py
@@ -1,6 +1,7 @@
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 import importlib
+import os
 import subprocess
 import sys
 import threading
@@ -39,9 +40,47 @@ def _forbid_popen(*_args, **_kwargs):
     raise AssertionError("subprocess.Popen requires an explicit hermetic test stub")
 
 
-def _load_mcp_server(monkeypatch, *, popen_stub=None):
+def _semantic_retriever(content):
+    document = type("Document", (), {"id": 0, "content": content})()
+
+    class FakeRetriever:
+        documents = [document]
+
+        def search_direct(self, _query, *, top_k):
+            return {
+                "results": [
+                    {"content": document.content, "relevance_score": 0.5}
+                ]
+            }
+
+    return FakeRetriever()
+
+
+def _load_mcp_server(
+    monkeypatch, *, popen_stub=None, bm25_load=None, bm25_cache_exists=None
+):
     monkeypatch.setattr(subprocess, "Popen", popen_stub or _forbid_popen)
     calls = []
+    if bm25_cache_exists is not None:
+        original_exists = os.path.exists
+        monkeypatch.setattr(
+            os.path,
+            "exists",
+            lambda path: bm25_cache_exists
+            if str(path).endswith("bm25.npz")
+            else original_exists(path),
+        )
+    bm25_module = ModuleType("embeddinggemma.bm25_lite")
+
+    class BM25Lite:
+        @staticmethod
+        def load(path):
+            if bm25_load is None:
+                raise AssertionError("BM25Lite.load requires an explicit hermetic test stub")
+            return bm25_load(path)
+
+    bm25_module.BM25Lite = BM25Lite
+    monkeypatch.setitem(sys.modules, "embeddinggemma.bm25_lite", bm25_module)
     generation = ModuleType("embeddinggemma.rag.generation")
 
     def generate_text(**kwargs):
@@ -142,6 +181,87 @@ def test_index_stats_reports_lazy_state_without_starting_loader(monkeypatch):
 
     assert "not loaded yet" in result.lower()
     assert NoStartThread.starts == 0
+
+
+def test_bm25_load_waits_for_a_hybrid_search_not_import_or_index_stats(monkeypatch):
+    loads = []
+    server, _calls = _load_mcp_server(
+        monkeypatch,
+        bm25_load=lambda path: loads.append(path),
+        bm25_cache_exists=True,
+    )
+
+    assert loads == []
+    assert "not loaded yet" in asyncio.run(server.fungus_index_stats()).lower()
+    assert loads == []
+
+
+def test_parallel_hybrid_searches_hydrate_bm25_once(monkeypatch):
+    load_started = threading.Event()
+    release_load = threading.Event()
+    loads = []
+
+    class FakeBM25:
+        doc_freq = {}
+        N = 1
+
+        def score(self, _query, *, candidate_ids):
+            return server._np.asarray(
+                [float(candidate_id) for candidate_id in candidate_ids]
+            )
+
+    def fake_load(path):
+        loads.append(path)
+        load_started.set()
+        assert release_load.wait(timeout=2)
+        return FakeBM25()
+
+    server, _calls = _load_mcp_server(monkeypatch, bm25_load=fake_load)
+    monkeypatch.setattr(server.os.path, "exists", lambda path: path == server._bm25_path)
+    monkeypatch.setattr(server, "_ensure_ready", lambda: True)
+    server._retriever = _semantic_retriever(
+        "# file: example.py | lines: 1-1\ndef search(): pass"
+    )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(server._sync_search, "hybrid", 1, 0.65)
+        assert load_started.wait(timeout=2)
+        second = executor.submit(server._sync_search, "hybrid", 1, 0.65)
+        release_load.set()
+        first_results = first.result(timeout=2)["results"]
+        second_results = second.result(timeout=2)["results"]
+
+    assert loads == [server._bm25_path]
+    assert "_bm25_score" in first_results[0]
+    assert "_bm25_score" in second_results[0]
+
+
+@pytest.mark.parametrize(
+    ("cache_exists", "load_error", "expected_loads"),
+    [(False, False, 0), (True, True, 1)],
+    ids=["missing-cache", "load-error"],
+)
+def test_bm25_hydration_failure_is_bounded_and_falls_back_to_semantic(
+    monkeypatch, cache_exists, load_error, expected_loads
+):
+    loads = []
+
+    def fake_load(path):
+        loads.append(path)
+        if load_error:
+            raise OSError("corrupt cache")
+        raise AssertionError("missing cache must not call BM25Lite.load")
+
+    server, _calls = _load_mcp_server(monkeypatch, bm25_load=fake_load)
+    monkeypatch.setattr(server.os.path, "exists", lambda _path: cache_exists)
+    monkeypatch.setattr(server, "_ensure_ready", lambda: True)
+    server._retriever = _semantic_retriever(
+        "# file: fallback.py | lines: 1-1\ndef fallback(): pass"
+    )
+
+    assert server._sync_search("fallback", 1, 0.65)["results"]
+    assert server._sync_search("fallback", 1, 0.65)["results"]
+    assert len(loads) == expected_loads
 
 
 def test_first_retriever_query_spawns_incremental_updater_once(monkeypatch):


### PR DESCRIPTION
## Summary
- remove BM25 cache hydration from MCP module import and handshake
- hydrate the optional BM25 cache only at the first hybrid-search boundary
- serialize concurrent hydration and bound missing-cache/load-failure handling to one attempt per process
- keep index_stats non-hydrating and preserve semantic fallback

## Scope
- mcp_server.py
- tests/tools/test_mcp_server_openfang.py

## Verification
- RED: 3 expected failures across the new import/concurrency/failure cases
- GREEN: 12 passed
- git diff --check: clean
- exact two-path scope: verified
- tests use no real model, index, GPU, network, or subprocess updater

## Non-claims
This does not centralize MCP transport, share retrievers across processes, or bound memory after a real retrieval request. It only removes eager BM25 cache hydration from startup.